### PR TITLE
壊れたPkgInfoが作成される

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -88,7 +88,7 @@ MACINFOPLIST		= $(BUNDLE)/Contents/Info.plist
 # OSX Info.plist用の設定
 COMPANY			= ????
 BUNDLEPACKAGE		= APPL
-BUNDLESIGNATURE		= ???
+BUNDLESIGNATURE		= ????
 
 #
 # Windows(x86)向けのインストーラ作成(クロスコンパイラ向け)
@@ -355,7 +355,7 @@ $(MACICON):
 $(MACPKGINFO):
 	@echo "==== Creating PkgInfo ===="
 	touch $(MACPKGINFO)
-	@echo -n "$(BUNDLEPACKAGE)$(BUNDLESIGNATURE)" > $(MACPKGINFO)
+	@/bin/echo -n "$(BUNDLEPACKAGE)$(BUNDLESIGNATURE)" > $(MACPKGINFO)
 
 #  This creates the Contents/Info.plist file.
 $(MACINFOPLIST):


### PR DESCRIPTION
`Contents/PkgInfo`の中身がこんなことになっています

> -n APPL???

`make`がコマンドの実行に用いている`/bin/sh`の内蔵`echo`コマンドには`-n`オプションが無いのでそのまま書き込まれてしまうそうです
